### PR TITLE
Fix test event listener for nested and unlabeled tests

### DIFF
--- a/workspace/test.ml
+++ b/workspace/test.ml
@@ -3,24 +3,51 @@ open OUnit
 let _esc_lf s =
   s |> Str.global_replace (Str.regexp_string "\n") "<:LF:>";;
 
-(* TODO Fix missing `<COMPLETEDIN::>` *)
+let cw_print_success = function
+  | _ -> print_endline ("\n<PASSED::>Test passed")
+  
+let cw_print_failure = function
+  | err -> print_endline ("\n<FAILED::>" ^ (_esc_lf err))
+
+let cw_print_error = function
+  | err -> print_endline ("\n<ERROR::>" ^ (_esc_lf err))  
+  
+let cw_print_result = function
+  | RSuccess _        -> cw_print_success()
+  | RFailure(_, err) -> cw_print_failure err
+  | RError  (_, err) -> cw_print_error err
+  | _        -> ()
+  
 let cw_print_test_event = function
-  | EStart (name::rest) -> print_endline ("\n<IT::>" ^ string_of_node name)
-  | EResult result ->
-    begin match result with
-      | RSuccess _ -> print_endline ("\n<PASSED::>Test passed")
-      | RFailure (_, err) -> print_endline ("\n<FAILED::>" ^ (_esc_lf err))
-      | RError (_, err) -> print_endline ("\n<ERROR::>" ^ (_esc_lf err))
-      | _ -> ()
-    end
+  | EResult result -> cw_print_result result
   | _ -> ()
 
-let run_test = function
-  | TestLabel (name, suite) -> begin
-    print_endline ("\n<DESCRIBE::>" ^ name);
-    perform_test cw_print_test_event suite
+let rec dispatch_test_group = function
+  | label, TestList tests -> begin
+    print_endline("\n<DESCRIBE::>"^label);
+    run_tests tests;
+    print_endline("\n<COMPLETEDIN::>");
   end
-  | suite -> perform_test cw_print_test_event suite
+  
+and dispatch_test_case = function
+  | label, test_case -> begin
+    print_endline("\n<IT::>"^label);
+    perform_test cw_print_test_event test_case |> ignore;
+    print_endline("\n<COMPLETEDIN::>");
+  end  
+  
+and dispatch_labeled_test = function
+  | label, TestLabel (nested_label, test) -> dispatch_labeled_test (nested_label, test)
+  | label, TestCase test_fun -> dispatch_test_case(label, TestCase test_fun)
+  | label, TestList test_group -> dispatch_test_group(label, TestList test_group)
+  
+and run_test = function
+  | TestList tests -> "" >::: tests |> run_test
+  | TestCase func ->  "" >::  func  |> run_test
+  | TestLabel(label, test) -> dispatch_labeled_test(label, test)
 
-(* Solution and Tests are concatenated to `fixture.ml` *)
-let _ = List.map run_test Fixture.Tests.suite |> ignore
+and run_tests = function
+  | tests -> List.iter run_test tests
+  
+(* `solution` and `fixture` are concatenated to `fixture.ml` *)
+let () = run_tests Fixture.Tests.suite

--- a/workspace/test.ml
+++ b/workspace/test.ml
@@ -1,53 +1,44 @@
 open OUnit
 
-let _esc_lf s =
-  s |> Str.global_replace (Str.regexp_string "\n") "<:LF:>";;
+let _esc_lf = Str.global_replace (Str.regexp_string "\n") "<:LF:>"
 
-let cw_print_success = function
-  | _ -> print_endline ("\n<PASSED::>Test passed")
+let cw_print_success () = print_endline "\n<PASSED::>Test passed"
   
-let cw_print_failure = function
-  | err -> print_endline ("\n<FAILED::>" ^ (_esc_lf err))
+let cw_print_failure err = print_endline ("\n<FAILED::>" ^ _esc_lf err)
 
-let cw_print_error = function
-  | err -> print_endline ("\n<ERROR::>" ^ (_esc_lf err))  
+let cw_print_error err = print_endline ("\n<ERROR::>" ^ _esc_lf err)  
   
 let cw_print_result = function
-  | RSuccess _        -> cw_print_success()
-  | RFailure(_, err) -> cw_print_failure err
-  | RError  (_, err) -> cw_print_error err
-  | _        -> ()
+  | RSuccess _        -> cw_print_success ()
+  | RFailure (_, err) -> cw_print_failure err
+  | RError   (_, err) -> cw_print_error err
+  | RSkip _ | RTodo _ -> ()
   
 let cw_print_test_event = function
-  | EResult result -> cw_print_result result
-  | _ -> ()
+  | EResult result    -> cw_print_result result
+  | EStart _ | EEnd _ -> ()
 
-let rec dispatch_test_group = function
-  | label, TestList tests -> begin
-    print_endline("\n<DESCRIBE::>"^label);
+let dispatch_test_case label test_case =
+  print_endline ("\n<IT::>" ^ label);
+  perform_test cw_print_test_event test_case |> ignore;
+  print_endline "\n<COMPLETEDIN::>"
+  
+let rec dispatch_labeled_test label test =
+  match test with
+  | TestLabel (nested_label, nested_test) -> dispatch_labeled_test nested_label nested_test
+  | TestCase _ -> dispatch_test_case label test
+  | TestList tests -> begin
+    print_endline ("\n<DESCRIBE::>" ^ label);
     run_tests tests;
-    print_endline("\n<COMPLETEDIN::>");
+    print_endline "\n<COMPLETEDIN::>";
   end
-  
-and dispatch_test_case = function
-  | label, test_case -> begin
-    print_endline("\n<IT::>"^label);
-    perform_test cw_print_test_event test_case |> ignore;
-    print_endline("\n<COMPLETEDIN::>");
-  end  
-  
-and dispatch_labeled_test = function
-  | label, TestLabel (nested_label, test) -> dispatch_labeled_test (nested_label, test)
-  | label, TestCase test_fun -> dispatch_test_case(label, TestCase test_fun)
-  | label, TestList test_group -> dispatch_test_group(label, TestList test_group)
   
 and run_test = function
   | TestList tests -> "" >::: tests |> run_test
   | TestCase func ->  "" >::  func  |> run_test
-  | TestLabel(label, test) -> dispatch_labeled_test(label, test)
+  | TestLabel (label, test) -> dispatch_labeled_test label test
 
-and run_tests = function
-  | tests -> List.iter run_test tests
+and run_tests tests = List.iter run_test tests
   
 (* `solution` and `fixture` are concatenated to `fixture.ml` *)
 let () = run_tests Fixture.Tests.suite


### PR DESCRIPTION
Fixes #1 .

Supports:
 - Nested tests.
 - Tests without labels.

Example kumite: https://www.codewars.com/kumite/620a7361d746e5000f36a021/

Test output:

```text
<IT::>Top level test case

<FAILED::>not equal

<COMPLETEDIN::>

<DESCRIBE::>Test Odd

<IT::>Should return false for 1

<PASSED::>Test passed

<COMPLETEDIN::>

<IT::>Should return false for 7

<PASSED::>Test passed

<COMPLETEDIN::>

<COMPLETEDIN::>

<DESCRIBE::>Test even

<IT::>Should return true for 100

<PASSED::>Test passed

<COMPLETEDIN::>

<IT::>Should return true for 42

<PASSED::>Test passed

<COMPLETEDIN::>

<COMPLETEDIN::>

<DESCRIBE::>Test edge cases

<DESCRIBE::>Test zero

<IT::>Should return true for 0

<PASSED::>Test passed

<COMPLETEDIN::>

<COMPLETEDIN::>

<DESCRIBE::>Test -1

<IT::>Should return false for -1

<PASSED::>Test passed

<COMPLETEDIN::>

<COMPLETEDIN::>

<COMPLETEDIN::>

<DESCRIBE::>Unlabeled tests

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>

<DESCRIBE::>

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>

<COMPLETEDIN::>

<COMPLETEDIN::>
```

Current output panel:

![image](https://user-images.githubusercontent.com/23709795/154108481-43f1315f-53bb-4a82-a50c-9e7602b6eeab.png)

Output panel with updated listener:

![image](https://user-images.githubusercontent.com/23709795/154108397-80978b9d-cb31-4bec-bd19-b48ca2079218.png)
