### PR TITLE
Nested tests with labels and completion durations

### DIFF
--- a/workspace/test.ml
+++ b/workspace/test.ml
@@ -34,7 +34,12 @@ let dispatch_test_case label test_case =
   
 let rec dispatch_labeled_test label test =
   match test with
-  | TestLabel (nested_label, nested_test) -> dispatch_labeled_test nested_label nested_test
+  | TestLabel (nested_label, nested_test) -> begin
+    cw_print_describe label;
+    let start = Unix.gettimeofday () in
+    dispatch_labeled_test nested_label nested_test;
+    cw_print_completed (Unix.gettimeofday () -. start)
+  end
   | TestCase _ -> dispatch_test_case label test
   | TestList tests -> begin
     cw_print_describe label;
@@ -42,7 +47,7 @@ let rec dispatch_labeled_test label test =
     run_tests tests;
     cw_print_completed (Unix.gettimeofday () -. start)
   end
-  
+
 and run_test = function
   | TestList tests -> "" >::: tests |> run_test
   | TestCase func ->  "" >::  func  |> run_test

--- a/workspace/test.ml
+++ b/workspace/test.ml
@@ -7,7 +7,15 @@ let cw_print_success () = print_endline "\n<PASSED::>Test passed"
 let cw_print_failure err = print_endline ("\n<FAILED::>" ^ _esc_lf err)
 
 let cw_print_error err = print_endline ("\n<ERROR::>" ^ _esc_lf err)  
-  
+
+let cw_print_it label = print_endline ("\n<IT::>" ^ label)
+
+let cw_print_describe label = print_endline ("\n<DESCRIBE::>" ^ label)
+
+let cw_print_completed t = 
+  Printf.sprintf "\n<COMPLETEDIN::>%.2f" (t *. 1000.0)
+  |> print_endline
+
 let cw_print_result = function
   | RSuccess _        -> cw_print_success ()
   | RFailure (_, err) -> cw_print_failure err
@@ -19,18 +27,20 @@ let cw_print_test_event = function
   | EStart _ | EEnd _ -> ()
 
 let dispatch_test_case label test_case =
-  print_endline ("\n<IT::>" ^ label);
+  cw_print_it label;
+  let start = Unix.gettimeofday () in
   perform_test cw_print_test_event test_case |> ignore;
-  print_endline "\n<COMPLETEDIN::>"
+  cw_print_completed (Unix.gettimeofday () -. start)
   
 let rec dispatch_labeled_test label test =
   match test with
   | TestLabel (nested_label, nested_test) -> dispatch_labeled_test nested_label nested_test
   | TestCase _ -> dispatch_test_case label test
   | TestList tests -> begin
-    print_endline ("\n<DESCRIBE::>" ^ label);
+    cw_print_describe label;
+    let start = Unix.gettimeofday () in
     run_tests tests;
-    print_endline "\n<COMPLETEDIN::>";
+    cw_print_completed (Unix.gettimeofday () -. start)
   end
   
 and run_test = function


### PR DESCRIPTION
Fixes #3.

Nested tests with labels are supported as test groups (`DESCRIBE`).

Example kumite: https://www.codewars.com/kumite/620a7361d746e5000f36a021/

Test output:

```text
<IT::>Top level test case

<FAILED::>not equal

<COMPLETEDIN::>0.17

<DESCRIBE::>Test Odd

<IT::>Should return false for 1

<PASSED::>Test passed

<COMPLETEDIN::>0.73

<IT::>Should return false for 7

<PASSED::>Test passed

<COMPLETEDIN::>0.57

<COMPLETEDIN::>1.43

<DESCRIBE::>Test even

<IT::>Should return true for 100

<PASSED::>Test passed

<COMPLETEDIN::>1.43

<IT::>Should return true for 42

<PASSED::>Test passed

<COMPLETEDIN::>1.42

<COMPLETEDIN::>3.50

<DESCRIBE::>Test edge cases

<DESCRIBE::>Test zero

<IT::>Should return true for 0

<PASSED::>Test passed

<COMPLETEDIN::>0.65

<COMPLETEDIN::>0.72

<DESCRIBE::>Test -1

<IT::>Should return false for -1

<PASSED::>Test passed

<COMPLETEDIN::>1.21

<COMPLETEDIN::>1.29

<COMPLETEDIN::>2.04

<DESCRIBE::>Unlabeled tests

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>1.98

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>1.99

<DESCRIBE::>

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>1.31

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>not equal

<COMPLETEDIN::>1.13

<COMPLETEDIN::>2.68

<COMPLETEDIN::>6.76

<DESCRIBE::>Nested labels

<DESCRIBE::>Outer label

<DESCRIBE::>Inner label

<DESCRIBE::>Tests with nested labels

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>expected: false but got: true

<COMPLETEDIN::>2.06

<IT::>

<FAILED::>Incorrect answer for n=100<:LF:>expected: false but got: true

<COMPLETEDIN::>1.29

<COMPLETEDIN::>3.55

<COMPLETEDIN::>3.56

<COMPLETEDIN::>3.56

<COMPLETEDIN::>3.57
```